### PR TITLE
Add supported audio formats

### DIFF
--- a/PlayniteSounds.cs
+++ b/PlayniteSounds.cs
@@ -1613,7 +1613,7 @@ namespace PlayniteSounds
 
         private List<string> SelectMusicForDirectory(string directory)
         {
-            var newMusicFiles = PlayniteApi.Dialogs.SelectFiles("Music Files(*.mp3;*.wav;*.ogg;*.flac)|*.mp3;*.wav;*.ogg;*.flac") ?? new List<string>();
+            var newMusicFiles = PlayniteApi.Dialogs.SelectFiles("Music Files(*.mp3;*.wav;*.flac;*.wma;*.aif;*.m4a;*.aac;*.mid)|*.mp3;*.wav;*.flac;*.wma;*.aif;*.m4a;*.aac;*.mid") ?? new List<string>();
 
             foreach (var musicFile in newMusicFiles)
             {


### PR DESCRIPTION
Remove `ogg` and add compatible formats according to [this page](https://support.microsoft.com/en-us/topic/file-types-supported-by-windows-media-player-32d9998e-dc8f-af54-7ba1-e996f74375d9) (yes, `mid` files work :-D)